### PR TITLE
network.Server: use handler.run() instead of handler.start()

### DIFF
--- a/mc4p/network.py
+++ b/mc4p/network.py
@@ -301,7 +301,7 @@ class Server(gevent.server.StreamServer):
     def handle(self, sock, addr):
         logger.info("Incoming connection from %s:%d" % addr)
         handler = self.handler(sock, addr, self)
-        handler.start()
+        handler.run()
 
     def run(self):
         try:


### PR DESCRIPTION
According to http://www.gevent.org/gevent.baseserver.html, when the handler 
returns the socket is closed. `Greenlet.start()` is a scheduling function and
returns immediately, which in turn closes the socket. As Minecraft use a
persistent connection, closing the socket would be undesireable. Instead, 
`Greenlet.run()` calls `Endpoint._run()`, which waits for the handler to
finish execution, keeping the connection persistent.